### PR TITLE
fix(code): do single assocation instead of batch for workitem updates

### DIFF
--- a/.taskkey
+++ b/.taskkey
@@ -1,1 +1,1 @@
-15aa6e49-58b5-4b50-baaf-1bf38f483f1c
+75d3998c-b9dc-452b-be06-5ffb9754eda4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-test-binder",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Associate Azure Devops Work Items To Automated tests",
   "license": "MIT",
   "author": "James Dunnam",

--- a/src/workitem/utils.ts
+++ b/src/workitem/utils.ts
@@ -99,3 +99,53 @@ export const toWorkItemTestDto = (
   testRefId,
   workItemId,
 })
+
+type ErrorHandler<E> = (err: unknown) => E | undefined
+type AsyncForEachResult<R, E> = [R[], E[]]
+type AsyncForEachCallback<T> = (element: T, index?: number, array?: T[]) => Promise<void>
+
+/**
+ * Perform an async operation over the items in a collection.
+ *
+ * @param array - The collection of `T` to operate on
+ * @param callback - The async operation
+ * @param errorHandler - The error
+ */
+export const asyncForEach = async <T, R, E>(
+  array: T[],
+  callback: AsyncForEachCallback<T>,
+  errorHandler: ErrorHandler<E>,
+): Promise<E[]> => {
+  let index = 0
+  const errors: E[] = []
+
+  for (const item of array) {
+    try {
+      await callback(item, index++, array)
+    } catch (O_o: unknown) {
+      const items = errorHandler(O_o)
+
+      if (items) {
+        errors.push(items)
+      }
+    }
+  }
+
+  return errors
+}
+
+/**
+ * Guard function to check if a value is a `string`
+ * @param s - the value to check.
+ */
+export const isString = (s: unknown): s is string => {
+  return typeof s === 'string'
+}
+
+/**
+ * Guard function to check if a value is an {@link Error}
+ * @param e - the value to check.
+ */
+export const isError = (e: unknown): e is Error => {
+  return e instanceof Error
+}

--- a/task.json
+++ b/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 0,
     "Minor": 2,
-    "Patch": 3
+    "Patch": 4
   },
   "instanceNameFormat": "Azure Test Binder",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "azure-test-binder",
   "name": "Azure Test Binder",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "Superformula",
   "targets": [
     {


### PR DESCRIPTION
Batch updates to workitems are atomic. If one update fails, the whole batch fails.

## Description

Change batch updates for work items to individual updates.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
